### PR TITLE
add dummy code for api request

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,5 +40,6 @@
     "@babel/core": "^7.7.7",
     "@storybook/react": "^5.2.8",
     "babel-loader": "^8.0.6"
-  }
+  },
+  "proxy": "http://localhost:8001"
 }

--- a/src/App.js
+++ b/src/App.js
@@ -7,8 +7,13 @@ import Login from './components/Login'
 import Register from './components/Register'
 import User from './components/User'
 import Info from './components/Job/Info'
+import axios from 'axios'
 
 function App() {
+  axios.get("http://localhost:8001/api/getList")
+  .then((val) => {
+    console.log(val.data)
+  });
   return (
     <div className="App">
       <Home></Home>      


### PR DESCRIPTION
deleted old server repository and set up new one. still needs much work but the basic get request will work on the main application once server is run. it runs on 8001.
On this pull: remember to npm install for new dependancies

For server,
Clone: https://github.com/jusungchai/LHL-Final-Server
run npm install and then npm start.
run the application and upon connection, check developer console to see that get request indeed works by seeing the array: ["item1", "item2", "item3"]